### PR TITLE
Optimize performance and switch to Argon2 for password hashing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@types/express-rate-limit": "^5.1.3",
         "@types/hpp": "^0.2.6",
         "@types/jsonwebtoken": "^9.0.9",
+        "argon2": "^0.41.1",
         "bcrypt": "^5.1.1",
         "bcryptjs": "^3.0.2",
         "bson-objectid": "^2.0.4",
@@ -2681,6 +2682,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@phc/format": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@phc/format/-/format-1.0.0.tgz",
+      "integrity": "sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -3240,6 +3250,30 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/argon2": {
+      "version": "0.41.1",
+      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.41.1.tgz",
+      "integrity": "sha512-dqCW8kJXke8Ik+McUcMDltrbuAWETPyU6iq+4AhxqKphWi7pChB/Zgd/Tp/o8xRLbg8ksMj46F/vph9wnxpTzQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@phc/format": "^1.0.0",
+        "node-addon-api": "^8.1.0",
+        "node-gyp-build": "^4.8.1"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/argon2/node_modules/node-addon-api": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.1.tgz",
+      "integrity": "sha512-lytcDEdxKjGJPTLEfW4mYMigRezMlyJY8W4wxJK8zE533Jlb8L8dRuObJFWg2P+AuOIxoCgKF+2Oq4d4Zd0OUA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -7372,6 +7406,17 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-int64": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@types/express-rate-limit": "^5.1.3",
     "@types/hpp": "^0.2.6",
     "@types/jsonwebtoken": "^9.0.9",
+    "argon2": "^0.41.1",
     "bcrypt": "^5.1.1",
     "bcryptjs": "^3.0.2",
     "bson-objectid": "^2.0.4",

--- a/src/config/db.ts
+++ b/src/config/db.ts
@@ -1,11 +1,13 @@
 import mongoose from 'mongoose'
 import { GLOBAL } from 'myapp'
 import goodlog from 'good-logs'
+import { User } from 'model'
 
 const TAG = 'DB'
 export const connectDb = async (isConnected: boolean) => {
   try {
     const db = await mongoose.connect(String(GLOBAL.DB_URI))
+    await User.syncIndexes()
     const _host = GLOBAL.DB_HOST(db.connection)
     const _name = GLOBAL.DB_NAME(db.connection)
     goodlog.db(_host, _name, isConnected)

--- a/src/config/global.ts
+++ b/src/config/global.ts
@@ -19,6 +19,12 @@ export const GLOBAL = {
     ENCODING: process.env.ENCRYPTION_ENCODING || '',
     ALG: process.env.ENCRYPTION_ALG || '',
   },
+  HASH   : {
+  TYPE       : process.env.HASH_TYPE || 'argon2id',
+  MEMORY_COST: parseInt(process.env.HASH_MEMORY_COST || '19456', 10),
+  TIME_COST  : parseInt(process.env.HASH_TIME_COST || '2', 10),
+  PARALLELISM: parseInt(process.env.HASH_PARALLELISM || '1', 10),
+  },
   RATE_LIMIT: {
     windowMs: 10 * 60 * 1000,
     max     : process.env.MAX_RATE_LIMIT

--- a/src/controller/service.ts
+++ b/src/controller/service.ts
@@ -55,9 +55,6 @@ export class Service {
   }
 
   public static async createUser(data: any) {
-    const { email } = data
-
-    await Service.checkExistence(User, { email }, RESPONSE.ERROR.DOCUMENT_EXISTS)
     const newUser = await User.create(data)
     return newUser
   }

--- a/src/model/User.ts
+++ b/src/model/User.ts
@@ -11,10 +11,10 @@ const TAG = 'User'
 const UserSchema: Schema<IUser> = new Schema<IUser>(
   {
     firstname: {
-      type: String,
+      type    : String,
       required: [true, getLocale('validation.default.required', { field: 'Firstname' })],
-      min: 3,
-      max: 20,
+      min     : 3,
+      max     : 20,
       validate: {
         validator: function (v: string) {
           return v.length > 3 && v.length < 20
@@ -24,8 +24,8 @@ const UserSchema: Schema<IUser> = new Schema<IUser>(
     },
 
     lastname: {
-      type: String,
-      max: 20,
+      type    : String,
+      max     : 20,
       validate: {
         validator: function (v: string) {
           return v.length < 20
@@ -34,16 +34,17 @@ const UserSchema: Schema<IUser> = new Schema<IUser>(
       },
     },
     email: {
-      type: String,
+      type    : String,
       required: [true, getLocale('validation.default.length', { field: 'Email' })],
-      unique: [true, getLocale('validation.default.unique', { field: 'Email' })],
-      match: [REGEX.EMAIL, getLocale('validation.default.invalid', { field: 'email' })],
+      unique  : [true, getLocale('validation.default.unique', { field: 'Email' })],
+      match   : [REGEX.EMAIL, getLocale('validation.default.invalid', { field: 'email' })],
+      index   : true
     },
     password: {
-      type: String,
+      type    : String,
       required: [true, getLocale('validation.default.length', { field: 'Password', min: 6, max: 20 })],
-      min: 6,
-      select: false,
+      min     : 6,
+      select  : false,
     }
   },
   {
@@ -58,7 +59,7 @@ UserSchema.pre('save', async function(next) {
     if (!this.isModified('password')) {
         next()
     }
-    const salt          = await bcrypt.genSalt(10)
+    const salt          = await bcrypt.genSalt(8)
           this.password = await bcrypt.hash(this.password, salt)
 })
 

--- a/src/model/User.ts
+++ b/src/model/User.ts
@@ -61,11 +61,23 @@ UserSchema.pre('save', async function(next) {
         next()
     }
 
+    const hashTypeMap = {
+      argon2d : argon2.argon2d,
+      argon2i : argon2.argon2i,
+      argon2id: argon2.argon2id
+    } as const
+
+    const type = hashTypeMap[GLOBAL.HASH.TYPE as keyof typeof hashTypeMap]
+
+    if (!type) {
+      throw new Error(`Invalid hash type: ${GLOBAL.HASH.TYPE}`)
+    }
+
     this.password = await argon2.hash(this.password, {
-      type       : argon2.argon2id,
-      memoryCost : 19456,
-      timeCost   : 2,
-      parallelism: 1
+      type       : type,
+      memoryCost : GLOBAL.HASH.MEMORY_COST,
+      timeCost   : GLOBAL.HASH.TIME_COST,
+      parallelism: GLOBAL.HASH.PARALLELISM
     })
 })
 


### PR DESCRIPTION
Improve application performance by synchronizing user indexes on database connection and removing unnecessary email existence checks during user creation. Transition from bcrypt to Argon2 for password hashing to enhance security and performance.

Fixes #14, #18